### PR TITLE
Adding deployments and services for the decscloud dashboard and game UI

### DIFF
--- a/kube/dashboard-deployment.yaml
+++ b/kube/dashboard-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dashboard
+  name: dashboard
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: dashboard
+    spec:
+      containers:
+      - image: decscloud/dashboard
+        name: dashboard
+        ports:
+        - containerPort: 9090
+        resources: {}
+      - env:
+        - name: RESGATE_HOST
+          value: http://resgate:8080        
+      restartPolicy: Always
+status: {}

--- a/kube/dashboard-service.yaml
+++ b/kube/dashboard-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: dashboard
+  name: dashboard
+spec:
+  ports:
+  - name: "9090"
+    port: 9090
+    targetPort: 9090
+  selector:
+    app: dashboard
+status:
+  loadBalancer: {}

--- a/kube/gameui-deployment.yaml
+++ b/kube/gameui-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gameui
+  name: gameui
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gameui
+    spec:
+      containers:
+      - image: stacktrader/ui
+        name: gameui
+        ports:
+        - containerPort: 9090
+        resources: {}
+      - env:
+        - name: RESGATE_HOST
+          value: http://resgate:8080        
+      restartPolicy: Always
+status: {}

--- a/kube/gameui-service.yaml
+++ b/kube/gameui-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gameui
+  name: gameui
+spec:
+  ports:
+  - name: "9090"
+    port: 9090
+    targetPort: 9090
+  selector:
+    app: gameui
+status:
+  loadBalancer: {}


### PR DESCRIPTION
this does not include the two ingress objects that we'll need to allow external access to the two user interfaces. Those may end up being demo environment specific, so not sure whether they belong here or with the infra.