### PR TITLE
Fixed 10 items leaderboard

### DIFF
--- a/leaderboard/src/leaderboard.rs
+++ b/leaderboard/src/leaderboard.rs
@@ -151,15 +151,12 @@ pub(crate) fn handle_get_single(
     let idx: usize = tokens[3].parse()?; // decs.(shard).leaderboard.(idx)
     let shard = tokens[1];
     let ranks = rank_shard(SCORES.read().unwrap().get(shard));
-    let result = if idx < ranks.len() {
+    let result = 
         json!({
             "result": {
                 "model": ranks[idx]
             }
-        })
-    } else {
-        error_not_found("no such leaderboard entry")
-    };
+        });    
     ctx.msg()
         .publish(&msg.reply_to, None, &serde_json::to_vec(&result)?)?;
     Ok(vec![])

--- a/leaderboard/src/leaderboard.rs
+++ b/leaderboard/src/leaderboard.rs
@@ -5,10 +5,19 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use trader::components::*;
 
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 struct LeaderBoardEntry {
     pub player: String,
     pub amount: i32,
+}
+
+impl Default for LeaderBoardEntry {
+    fn default() -> Self {
+        LeaderBoardEntry {
+            player: "Nobody".to_string(),
+            amount: 0,
+        }
+    }
 }
 
 lazy_static! {
@@ -19,49 +28,30 @@ pub(crate) fn handle_frame(ctx: &CapabilitiesContext, msg: messaging::BrokerMess
     let frame: decs::systemmgr::EntityFrame = serde_json::from_slice(&msg.body)?;
 
     let wallet = get_wallet(ctx, &frame.shard, &frame.entity_id)?;
-    let old_ranks = if !SCORES.read().unwrap().contains_key(&frame.shard) {
-        vec![]
-    } else {
-        rank_shard(&SCORES.read().unwrap()[&frame.shard])
-    };
-    purge_leaderboard(ctx, &frame.shard, old_ranks.len())?;
-
+    let old_ranks = rank_shard(SCORES.read().unwrap().get(&frame.shard));
     put_score(&frame.shard, &frame.entity_id, wallet.credits)?;
-    let new_ranks = rank_shard(&SCORES.read().unwrap()[&frame.shard]);
-    publish_leaderboard(ctx, &frame.shard, &new_ranks)?;
+    let new_ranks = rank_shard(SCORES.read().unwrap().get(&frame.shard));
+    publish_changes(ctx, &frame.shard, &old_ranks, &new_ranks)?;
 
     Ok(vec![])
 }
 
-fn purge_leaderboard(
+fn publish_changes(
     ctx: &CapabilitiesContext,
     shard: &str,
-    rank_count: usize,
+    old: &[LeaderBoardEntry],
+    new: &[LeaderBoardEntry],
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    for _ in 0..rank_count {
-        ctx.msg().publish(
-            &format!("event.decs.{}.leaderboard.remove", shard),
-            None,
-            &serde_json::to_vec(&json!({ "idx": 0 }))?,
-        )?;
-    }
-    Ok(())
-}
-
-fn publish_leaderboard(
-    ctx: &CapabilitiesContext,
-    shard: &str,
-    ranks: &[LeaderBoardEntry],
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
-    for (i, _rank) in ranks.iter().enumerate() {
-        ctx.msg().publish(
-            &format!("event.decs.{}.leaderboard.add", shard),
-            None,
-            &serde_json::to_vec(&json!({
-                "value": ResourceIdentifier { rid: format!("decs.{}.leaderboard.{}", shard, i)},
-                "idx": i
-            }))?,
-        )?;
+    for i in 0..old.len() {
+        if old[i] != new[i] {
+            ctx.msg().publish(
+                &format!("event.decs.{}.leaderboard.{}.change", shard, i),
+                None,
+                &serde_json::to_vec(&json!({
+                    "values": new[i]
+                }))?,
+            )?;
+        }
     }
     Ok(())
 }
@@ -97,16 +87,31 @@ fn get_wallet(
     }
 }
 
-fn rank_shard(shardmap: &HashMap<String, i32>) -> Vec<LeaderBoardEntry> {
-    let mut entries: Vec<_> = shardmap
-        .iter()
-        .map(|(k, v)| LeaderBoardEntry {
-            player: k.clone(),
-            amount: *v,
-        })
-        .collect();
-    entries.sort_by(|a, b| b.amount.cmp(&a.amount));
-    entries
+// Rank all players according to their score, then return the top 10
+// if there are less than 10 players with scores, fill the remaining slots
+// with "Nobody"
+fn rank_shard(shardmap: Option<&HashMap<String, i32>>) -> Vec<LeaderBoardEntry> {
+    match shardmap {
+        Some(shardmap) => {
+            let mut entries: Vec<_> = shardmap
+                .iter()
+                .map(|(k, v)| LeaderBoardEntry {
+                    player: k.clone(),
+                    amount: *v,
+                })
+                .collect();
+            entries.sort_by(|a, b| b.amount.cmp(&a.amount));
+
+            let mut leaderboard: Vec<LeaderBoardEntry> = entries.into_iter().take(10).collect();
+            for _i in 0..10 - leaderboard.len() {
+                leaderboard.push(LeaderBoardEntry::default())
+            }
+            leaderboard
+        }
+        None => std::iter::repeat(LeaderBoardEntry::default())
+            .take(10)
+            .collect(),
+    }
 }
 
 pub(crate) fn handle_get_collection(
@@ -117,12 +122,7 @@ pub(crate) fn handle_get_collection(
     let tokens: Vec<_> = rid.split('.').collect();
     let shard = tokens[1]; // decs.(shard).leaderboard
 
-    // Return an empty collection if there are no scores in this shard yet
-    let ranks = if !SCORES.read().unwrap().contains_key(shard) {
-        vec![]
-    } else {
-        rank_shard(&SCORES.read().unwrap()[shard])
-    };
+    let ranks = rank_shard(SCORES.read().unwrap().get(shard));
 
     let rids: Vec<_> = ranks
         .iter()
@@ -150,7 +150,7 @@ pub(crate) fn handle_get_single(
     let tokens: Vec<_> = rid.split('.').collect();
     let idx: usize = tokens[3].parse()?; // decs.(shard).leaderboard.(idx)
     let shard = tokens[1];
-    let ranks = rank_shard(&SCORES.read().unwrap()[shard]);
+    let ranks = rank_shard(SCORES.read().unwrap().get(shard));
     let result = if idx < ranks.len() {
         json!({
             "result": {
@@ -163,37 +163,4 @@ pub(crate) fn handle_get_single(
     ctx.msg()
         .publish(&msg.reply_to, None, &serde_json::to_vec(&result)?)?;
     Ok(vec![])
-}
-
-#[cfg(test)]
-mod test {
-    use super::rank_shard;
-    use super::LeaderBoardEntry;
-    use std::collections::HashMap;
-
-    #[test]
-    fn test_simple_rank() {
-        let mut ranks = HashMap::new();
-        ranks.insert("bob".to_string(), 200);
-        ranks.insert("al".to_string(), 300);
-        ranks.insert("bobfred".to_string(), 500);
-
-        assert_eq!(
-            rank_shard(&ranks),
-            vec![
-                LeaderBoardEntry {
-                    player: "bobfred".to_string(),
-                    amount: 500
-                },
-                LeaderBoardEntry {
-                    player: "al".to_string(),
-                    amount: 300
-                },
-                LeaderBoardEntry {
-                    player: "bob".to_string(),
-                    amount: 200
-                }
-            ]
-        );
-    }
 }

--- a/leaderboard/src/lib.rs
+++ b/leaderboard/src/lib.rs
@@ -55,7 +55,9 @@ fn handle_message(
     if let Some(msg) = msg {
         if msg.subject == REGISTRY_SUBJECT {
             handle_ping(ctx, msg)
-        } else if msg.subject.starts_with("decs.frames.") && msg.subject.ends_with(".shard_ldrboard") {
+        } else if msg.subject.starts_with("decs.frames.")
+            && msg.subject.ends_with(".shard_ldrboard")
+        {
             leaderboard::handle_frame(ctx, msg)
         } else {
             match ResProtocolRequest::from(msg.subject.as_str()) {

--- a/testing/compose/stack-trader.yml
+++ b/testing/compose/stack-trader.yml
@@ -224,12 +224,12 @@ services:
       - "NATS_URL=nats://nats:4222"
       - "REDIS_URL=redis://redis:6379"
       - "NATS_SUBSCRIPTION=decs.frames.*.merchant, decs.system.registry"
-   leaderboard:
+  leaderboard:
     image: stacktrader/leaderboard
     expose:
-      - "9010"
+      - "9011"
     ports:
-      - "9010:9010"
+      - "9011:9011"
     links:
       - nats
       - redis
@@ -240,4 +240,4 @@ services:
       - "RUST_LOG=warn,cranelift_wasm=warn"
       - "NATS_URL=nats://nats:4222"
       - "REDIS_URL=redis://redis:6379"
-      - "NATS_SUBSCRIPTION=decs.frames.*.leaderboard,decs.system.registry,get.decs.*.leaderboard,get.decs.*.leaderboard.*,access.decs.*.leaderboard,access.decs.*.leaderboard.*"
+      - "NATS_SUBSCRIPTION=decs.frames.*.shard_ldrboard,decs.system.registry,get.decs.*.leaderboard,get.decs.*.leaderboard.*,access.decs.*.leaderboard,access.decs.*.leaderboard.*"


### PR DESCRIPTION
Even after being fixed, the previous leaderboard implementation would bounce the entire board every second. So if we had 300 players, we'd see them disappear and re-appear every second. To provide a better, more stable, and more efficient experience the leaderboard service now:
* returns 10 default items for every shard when no scores have yet been received
* always returns 10 items regardless of the number of scores in each shard
* publishes _model change_ events (rather than collection add/remove) for each leaderboard item that changes during a frame.