### PR TITLE
Force resgate to requery radar contacts upon change

### DIFF
--- a/radar/src/radar.rs
+++ b/radar/src/radar.rs
@@ -76,10 +76,6 @@ pub(crate) fn handle_frame(ctx: &CapabilitiesContext, msg: messaging::BrokerMess
                 Some(&ctx),
             )
         };
-        POSITIONS
-            .write()
-            .unwrap()
-            .insert(frame.entity_id, position.clone());
 
         let _results = updates
             .iter()
@@ -110,6 +106,22 @@ pub(crate) fn handle_frame(ctx: &CapabilitiesContext, msg: messaging::BrokerMess
             })
             .map(|(subject, payload)| publish_message(ctx, &subject, payload))
             .collect::<Vec<CallResult>>();
+
+        // If we modified a player's contacts at all, publish a change message to make
+        // RESgate requery the source of truth.
+        if !updates.is_empty() {
+            ctx.msg().publish(
+                "system.reset",
+                None,
+                &serde_json::to_vec(&serde_json::json!({
+                    "resources":
+                        [format!(
+                            "decs.components.{}.{}.radar_contacts",
+                            frame.shard, frame.entity_id
+                        )]
+                }))?,
+            )?;
+        }
     }
 
     Ok(vec![])
@@ -187,20 +199,10 @@ fn radar_updates(
                 } else {
                     Some(RadarContactDelta::Remove(rid))
                 }
-            } else if entity_id != ent_id
-                && within_radius(current_position, &pos, radar_receiver.radius)
+            } else if (entity_id != ent_id
+                && within_radius(current_position, &pos, radar_receiver.radius))
+                || ent_id == "starbase_0"
             {
-                let vector_to = current_position.vector_to(pos);
-                let transponder = transponder_for_entity(shard, &ent_id.clone());
-                Some(RadarContactDelta::Add(RadarContact {
-                    entity_id: ent_id.clone().to_string(),
-                    distance: vector_to.mag,
-                    distance_xy: vector_to.distance_xy,
-                    azimuth: vector_to.azimuth,
-                    elevation: vector_to.elevation,
-                    transponder,
-                }))
-            } else if ent_id == "starbase_0" {
                 let vector_to = current_position.vector_to(pos);
                 let transponder = transponder_for_entity(shard, &ent_id.clone());
                 Some(RadarContactDelta::Add(RadarContact {


### PR DESCRIPTION
Rather than create a new service that forces this to happen every 30 seconds (the "hack" approach), just publish a message every time a player's radar contacts change that will make RESgate requery the radar contact list.

RESgate's index-based caching can still get out of sync, but it will only stay out of sync until the next time the player's radar contacts change on the back-end.